### PR TITLE
Pivotal no longer looks after this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,3 @@
-# Contributing to Pivotal Projects
-
-We’d love to accept your patches and contributions to this project. Please review the following guidelines you'll need to follow in order to make a contribution.
-
-## Contributor License Agreement
-
-All contributors to this project must have a signed Contributor License Agreement (**"CLA"**) on file with us. The CLA grants us the permissions we need to use and redistribute your contributions as part of the project; you or your employer retain the copyright to your contribution. Head over to https://cla.pivotal.io/ to see your current agreement(s) on file or to sign a new one.
-
-We generally only need you (or your employer) to sign our CLA once and once signed, you should be able to submit contributions to any Pivotal project. 
-
-Note: if you would like to submit an "_obvious fix_" for something like a typo, formatting issue or spelling mistake, you may not need to sign the CLA. Please see our information on [obvious fixes](https://cla.pivotal.io/about#obvious-fix) for more details. 
-
 ## Code reviews
 
 All submissions, including submissions by project members, require review and we use GitHub's pull requests for this purpose. Please consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) if you need more information about using pull requests.


### PR DESCRIPTION
So there is no need for CLAs to be signed.